### PR TITLE
Feat/rx client: adds reactivex mode to runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For a quick peek at what this project does and how it works, try  `scripts/quick
    1. remove any copied plugins. 
    1. tear down the listener and broker.
 
-It offers six simple scenarios. 
+It offers eight simple scenarios. 
 
    * `no args` - runs a simple scenario without plugins.
    * `nrf9160` - runs with the `runner.conf` file set to `examples/nrf9160/thingy91.yml`
@@ -66,6 +66,8 @@ It offers six simple scenarios.
    * `itemPluginRich` - runs a richer scenario with the simpleMovingAverage item plugin.
    * `samplePlugin` - runs a scenario with the lpFileReader sample plugin.
    * `tlsBasic` - runs the simple scenario without plugins but sets up mosquitto to accept only TLS connections at the default TLS port - 8883.
+   * `rxBasic` - runs a simple scenario using a Reactivex enabled client. 
+   * `rxTlsBasic` - runs a simple scenario using a Reactivex enabled client, communicating with the broker over TLS.
 
 For example: 
 
@@ -82,11 +84,11 @@ RUNNING BASIC EXAMPLE
 ...
 ```
 
-**Note on tlsBasic**
+**Note on tlsBasic and rxTlsBasic**
 
-The `tlsBasic` scenario generates a self-signed certificate used to configure a mosquitto MQTT server running in a docker container.  The CN value of the generated certificates is defined as an IP address, which should match a host IP over which the mosquitto server is accessible.  The script `scripts/selfSignCert.sh` attempts to get such an IP address from a running ethernet or wifi interface, however this is not always reliable.  This value can also be declared using the environment variable `VD_HOST_IP`.  For example declare `$ export VD_HOST_IP=192.168.101.102` before running either `selfSignCert.sh` or `quickStart.sh`.  Other environment variables are available for setting subject values in certificates.  To view them run `scripts/selfSignCert.sh --help`.
+These scenarios generate a self-signed certificate used to configure a mosquitto MQTT server running in a docker container.  The CN value of the generated certificates is defined as an IP address, which should match a host IP over which the mosquitto server is accessible.  The script `scripts/selfSignCert.sh` attempts to get such an IP address from a running ethernet or wifi interface, however this is not always reliable.  This value can also be declared using the environment variable `VD_HOST_IP`.  For example declare `$ export VD_HOST_IP=192.168.101.102` before running either `selfSignCert.sh` or `quickStart.sh`.  Other environment variables are available for setting subject values in certificates.  To view them run `scripts/selfSignCert.sh --help`.
 
-If the `tlsBasic` scenario fails, for example the subscriber fails to connect thus ending in an `SSLHandshakeException`, try stopping the mosquitto server and cleaning up the environment with these commands: `scripts/broker stop` and `sudo scripts/broker clean -certs`.  Then try and run it again.  
+If either of these scenarios fails, for example the subscriber fails to connect thus ending in an `SSLHandshakeException`, try stopping the mosquitto server and cleaning up the environment with these commands: `scripts/broker stop` and `sudo scripts/broker clean -certs`.  Then try and run it again.  
 
 ## Basic Tasks
 
@@ -187,7 +189,10 @@ An alternate base property file can be defined through the environment variable 
 
 The file indicated by the `runner.conf` property must be a valid YAML file. It needs to define the following nodes.
 
-* `ttl` - time to live in milliseconds or how long the device runner should run.  
+* `ttl` - time to live in milliseconds or how long the device runner should run.
+* `mode` - (Optional) the mode to use when communicating with a broker. The following values are currently supported.
+   * `Block`, `Blocking` - blocks when communicating with the broker, waiting for acknowledgements on publish.  When this node is omitted the runner defaults to blocking mode.
+   * `Rx`, `Reactive`, `Reactivex` - uses reactive idioms when communicating asynchronously with the broker. 
 * `broker` - a configuration for connecting to an MQTT5 broker (see [below](#broker)).
 * `items` - a list of items to be included in a sample.  Item values will be generated randomly (see [below](#items)).
 * `samples` - a list of samples bound to a topic and including a payload based on an internal item list (see [below](#samples)).

--- a/scripts/quickStart.sh
+++ b/scripts/quickStart.sh
@@ -43,6 +43,8 @@ function help(){
   echo "$MY_NAME samplePlugin   - runs a configuration with a sample plugin"
   echo "$MY_NAME nrf9160        - runs without plugins but with example runner.conf"
   echo "$MY_NAME tlsBasic       - runs the basic configuration against mosquitto with TLS."
+  echo "$MY_NAME rxBasic        - runs a configuration using reactivex."
+  echo "$MY_NAME rxTlsBasic     - runs a configuration using reactivex against a TLS broker."
   echo "$MY_NAME help           - returns this message"
 }
 
@@ -349,6 +351,37 @@ function tlsBasic(){
   shutdown
 }
 
+function rxBasic(){
+  setup
+  printf "\n\nRUNNING REACTIVEX BASIC EXAMPLE\n"
+  printf "===============================\n"
+
+  scripts/runner.sh src/test/resources/testRunnerRxConfig.yml
+
+  printf "\n\nDONE PUBLISHING REACTIVEX BASIC EXAMPLE\n"
+  printf "=======================================\n"
+
+  read_log
+
+  shutdown
+}
+
+function rxTlsBasic(){
+  setup_tls
+  printf "\n\nRUNNING REACTIVE WITH TLS BASIC EXAMPLE\n"
+  printf "=======================================\n"
+
+  scripts/runner.sh src/test/resources/testRunnerRxTlsConfig.yml
+
+  printf "\n\nDONE PUBLISHING REACTIVE WITH TLS BASIC EXAMPLE\n"
+  printf "===============================================\n"
+
+  read_log
+
+  shutdown
+
+}
+
 # TODO use case with special runner config only
 
 case $1 in
@@ -366,6 +399,12 @@ case $1 in
      ;;
   "tlsBasic")
      tlsBasic
+     ;;
+  "rxBasic")
+     rxBasic
+     ;;
+  "rxTlsBasic")
+     rxTlsBasic
      ;;
   "")
      base_example

--- a/src/main/java/io/bonitoo/qa/DeviceRunner.java
+++ b/src/main/java/io/bonitoo/qa/DeviceRunner.java
@@ -86,7 +86,7 @@ public class DeviceRunner {
     }
   }
 
-  public static void blockingMain(List<Device> devices) {
+  protected static void blockingMain(List<Device> devices) {
 
     ExecutorService service = Executors.newFixedThreadPool(devices.size());
 
@@ -101,9 +101,7 @@ public class DeviceRunner {
     service.shutdown();
   }
 
-
-
-  public static void reactiveMain(List<Device> devices) {
+  protected static void reactiveMain(List<Device> devices) {
 
     // System.out.println("Starting device " + d.getId());
     Disposable dis = Flowable.fromIterable(devices)

--- a/src/main/java/io/bonitoo/qa/VirtualDeviceRuntimeException.java
+++ b/src/main/java/io/bonitoo/qa/VirtualDeviceRuntimeException.java
@@ -11,4 +11,5 @@ public class VirtualDeviceRuntimeException extends RuntimeException {
   public VirtualDeviceRuntimeException(String s, Throwable t) {
     super(s, t);
   }
+
 }

--- a/src/main/java/io/bonitoo/qa/conf/Mode.java
+++ b/src/main/java/io/bonitoo/qa/conf/Mode.java
@@ -1,5 +1,8 @@
 package io.bonitoo.qa.conf;
 
+/**
+ * Represents the modes for creating Mqtt Clients.
+ */
 public enum Mode {
 
   BLOCKING,

--- a/src/main/java/io/bonitoo/qa/conf/Mode.java
+++ b/src/main/java/io/bonitoo/qa/conf/Mode.java
@@ -1,0 +1,10 @@
+package io.bonitoo.qa.conf;
+
+public enum Mode {
+
+  BLOCKING,
+
+  REACTIVE,
+  ASYNC
+
+}

--- a/src/main/java/io/bonitoo/qa/conf/RunnerConfig.java
+++ b/src/main/java/io/bonitoo/qa/conf/RunnerConfig.java
@@ -26,7 +26,6 @@ public class RunnerConfig {
   List<DeviceConfig> devices;
   Long ttl;
 
-  // TODO add here rxOrBlocking config option.
   Mode mode = Mode.BLOCKING;
 
   @Override

--- a/src/main/java/io/bonitoo/qa/conf/RunnerConfig.java
+++ b/src/main/java/io/bonitoo/qa/conf/RunnerConfig.java
@@ -26,6 +26,9 @@ public class RunnerConfig {
   List<DeviceConfig> devices;
   Long ttl;
 
+  // TODO add here rxOrBlocking config option.
+  Mode mode = Mode.BLOCKING;
+
   @Override
   public String toString() {
     StringBuilder result = new StringBuilder(String.format("ttl:%d\nBroker: %s\n", ttl, broker));

--- a/src/main/java/io/bonitoo/qa/conf/RunnerConfigDeserializer.java
+++ b/src/main/java/io/bonitoo/qa/conf/RunnerConfigDeserializer.java
@@ -19,6 +19,28 @@ import java.util.List;
 
 public class RunnerConfigDeserializer extends VirDevDeserializer<RunnerConfig> {
 
+  protected static Mode parseMode(String modeNode) {
+
+    String cleanMode = modeNode.replace("\"", "");
+
+    switch (cleanMode.toUpperCase()) {
+      case "BLOCKING":
+      case "BLOCK":
+        return Mode.BLOCKING;
+      case "REACTIVE":
+      case "REACTIVEX":
+      case "RX":
+        return Mode.REACTIVE;
+      case "ASYNC":
+      case "ASYNCHRONOUS":
+        return Mode.ASYNC;
+      default:
+        throw new VirDevConfigException(
+          String.format("Unknown Mode type " + modeNode)
+        );
+    }
+  }
+
   public RunnerConfigDeserializer() {
     this(null);
   }
@@ -44,6 +66,8 @@ public class RunnerConfigDeserializer extends VirDevDeserializer<RunnerConfig> {
     JsonNode itemsNode = node.get("items"); // can be null
     JsonNode samplesNode = node.get("samples"); // can be null
     JsonNode devicesNode = node.get("devices");
+    // TODO node for mode - reactivex or blocking - default blocking
+    JsonNode modeNode = node.get("mode"); // can be null
 
     if (ttlNode == null
         && brokerNode == null
@@ -63,6 +87,8 @@ public class RunnerConfigDeserializer extends VirDevDeserializer<RunnerConfig> {
         ? new BrokerConfig(Config.getProp("default.broker.host"),
         Integer.parseInt(Config.getProp("default.broker.port")), null) :
         ctx.readValue(brokerNode.traverse(jsonParser.getCodec()), BrokerConfig.class);
+
+    final Mode mode = modeNode == null ? Mode.BLOCKING : parseMode(modeNode.toString());
 
     if (itemsNode != null) {
       for (JsonNode itemNode : itemsNode) {
@@ -95,6 +121,6 @@ public class RunnerConfigDeserializer extends VirDevDeserializer<RunnerConfig> {
       }
     }
 
-    return new RunnerConfig(broker, devices, ttl);
+    return new RunnerConfig(broker, devices, ttl, mode);
   }
 }

--- a/src/main/java/io/bonitoo/qa/conf/RunnerConfigDeserializer.java
+++ b/src/main/java/io/bonitoo/qa/conf/RunnerConfigDeserializer.java
@@ -66,7 +66,6 @@ public class RunnerConfigDeserializer extends VirDevDeserializer<RunnerConfig> {
     JsonNode itemsNode = node.get("items"); // can be null
     JsonNode samplesNode = node.get("samples"); // can be null
     JsonNode devicesNode = node.get("devices");
-    // TODO node for mode - reactivex or blocking - default blocking
     JsonNode modeNode = node.get("mode"); // can be null
 
     if (ttlNode == null

--- a/src/main/java/io/bonitoo/qa/device/GenericDevice.java
+++ b/src/main/java/io/bonitoo/qa/device/GenericDevice.java
@@ -1,24 +1,38 @@
 package io.bonitoo.qa.device;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import io.bonitoo.qa.VirtualDeviceRuntimeException;
 import io.bonitoo.qa.conf.Config;
+import io.bonitoo.qa.conf.Mode;
 import io.bonitoo.qa.conf.data.SampleConfig;
 import io.bonitoo.qa.conf.device.DeviceConfig;
 import io.bonitoo.qa.data.GenericSample;
 import io.bonitoo.qa.data.Sample;
+import io.bonitoo.qa.mqtt.client.MqttClient;
 import io.bonitoo.qa.mqtt.client.MqttClientBlocking;
+import io.bonitoo.qa.mqtt.client.MqttClientRx;
 import io.bonitoo.qa.plugin.PluginConfigException;
 import io.bonitoo.qa.plugin.sample.SamplePluginConfig;
 import io.bonitoo.qa.plugin.sample.SamplePluginMill;
 import io.bonitoo.qa.util.LogHelper;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
+
+import io.bonitoo.qa.util.VirDevWorkInProgressException;
+import io.reactivex.Flowable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.schedulers.Schedulers;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 
 /**
  * A Generic device configurable with a DeviceConfig.
@@ -31,9 +45,9 @@ public class GenericDevice extends Device {
 
   int number;
 
-  MqttClientBlocking client;
+  MqttClient client;
 
-  protected GenericDevice(MqttClientBlocking client, DeviceConfig config, int number) {
+  protected GenericDevice(MqttClient client, DeviceConfig config, int number) {
     this.config = config;
     this.sampleList = new ArrayList<>();
     this.client = client;
@@ -52,7 +66,7 @@ public class GenericDevice extends Device {
     }
   }
 
-  public static GenericDevice singleDevice(MqttClientBlocking client, DeviceConfig config) {
+  public static GenericDevice singleDevice(MqttClient client, DeviceConfig config) {
     return numberedDevice(client, config, 1);
   }
 
@@ -65,15 +79,19 @@ public class GenericDevice extends Device {
    * @param number - serial number for the device to be added to id and name fields in samples.
    * @return - a generic device.
    */
-  public static GenericDevice numberedDevice(MqttClientBlocking client,
+  public static GenericDevice numberedDevice(MqttClient client,
                                              DeviceConfig config, int number) {
     return new GenericDevice(client, config, number);
   }
 
-  @Override
-  public void run() {
 
-    long ttl = System.currentTimeMillis() + Config.ttl();
+  public void blockingRun(long ttl) throws InterruptedException {
+
+    if (! (this.client instanceof MqttClientBlocking)) {
+      throw new VirtualDeviceRuntimeException(
+        "Attempt to start blockingRun with non-blocking client " + this.client.getClass().getName()
+      );
+    }
 
     try {
       if (config.getJitter() > 0) {
@@ -106,6 +124,130 @@ public class GenericDevice extends Device {
     } finally {
       client.disconnect();
     }
+  }
+
+  public void reactiveRun(long ttl) {
+
+    if (! (this.client instanceof MqttClientRx)) {
+      throw new VirtualDeviceRuntimeException(
+        "Attempt to start reactiveRun with non-reactive client " + this.client.getClass().getName()
+      );
+    }
+
+    try {
+      if (config.getJitter() > 0) {
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(config.getJitter() * number));
+      }
+      logger.info(LogHelper.buildMsg(config.getId(), "Device Connection", ""));
+      client.connect();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    // todo set delay based on config
+    Flowable<Mqtt5Publish> messageFlow = Flowable.fromIterable(sampleList)
+        .concatMap(sample -> {
+//        sample.update();
+          Flowable<Sample> fs = Flowable.just(sample).delay(1000, TimeUnit.MILLISECONDS, Schedulers.io());
+//        System.out.println("DEBUG sample on thread " + Thread.currentThread().getName() + ":\n" + sample.toJson());
+          return fs;
+        })
+        .doOnNext(sample -> {
+          sample.update();
+          logger.debug("sample on thread " + Thread.currentThread().getName() + ":\n" + sample.toJson());
+        })
+        .doOnError(System.err::println)
+        .doOnComplete(() -> {
+          logger.debug("Flowable<Sample> complete on thread " + Thread.currentThread().getName());
+        })
+        .doOnCancel(() -> {
+          logger.error("Flowable<Sample> cancelled");
+        })
+        .map(sample ->
+          Mqtt5Publish.builder()
+            .topic(sample.getTopic())
+            .qos(MqttQos.EXACTLY_ONCE)
+            .payload(sample.toJson().getBytes())
+            .build()
+        )
+        .repeatUntil(new BooleanSupplier() {
+          @Override
+          public boolean getAsBoolean() throws Exception {
+            return Instant.now().toEpochMilli() > ttl;
+          }
+        });
+
+    Disposable disposable = ((MqttClientRx) client).getClient().publish(messageFlow)
+        .doOnNext(pubRes -> logger.debug(pubRes.toString()))
+        .doOnError(System.err::println)
+        .doOnComplete(() -> logger.debug(Thread.currentThread().getName() + " publishing samples complete"))
+        .subscribe();
+
+    while (!disposable.isDisposed()) {
+      System.out.println("Waiting for samples...");
+      LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(3000));
+    }
+
+    try {
+      client.disconnect();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  public void asyncRun(long ttl) {
+    throw new VirDevWorkInProgressException("asyncRun logic TBD");
+  }
+
+  @Override
+  public void run() {
+
+    long ttl = System.currentTimeMillis() + Config.ttl();
+
+    if (Config.getRunnerConfig().getMode() == Mode.REACTIVE ) {
+      reactiveRun(ttl);
+    } else if (Config.getRunnerConfig().getMode() == Mode.ASYNC) {
+      asyncRun(ttl);
+    } else {
+      try {
+        blockingRun(ttl);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /* try {
+      if (config.getJitter() > 0) {
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(config.getJitter() * number));
+      }
+      logger.info(LogHelper.buildMsg(config.getId(), "Device Connection", ""));
+      client.connect();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    try {
+      while (System.currentTimeMillis() < ttl) {
+        logger.debug(LogHelper.buildMsg(config.getId(),
+            "Wait to publish",
+            Long.toString((ttl - System.currentTimeMillis()))));
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(config.getJitter()));
+        for (Sample sample : sampleList) {
+          String jsonSample = sample.update().toJson();
+          logger.info(LogHelper.buildMsg(sample.getId(), "Publishing", jsonSample));
+          client.publish(sample.getTopic(), jsonSample);
+        }
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(config.getInterval()));
+      }
+      logger.debug(LogHelper.buildMsg(config.getId(),
+          "Published",
+          Long.toString((ttl - System.currentTimeMillis()))));
+    } catch (JsonProcessingException | InterruptedException e) {
+      throw new RuntimeException(e);
+    } finally {
+      client.disconnect();
+    } */
 
   }
 }

--- a/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientAsync.java
+++ b/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientAsync.java
@@ -1,13 +1,17 @@
 package io.bonitoo.qa.mqtt.client;
 
+import com.hivemq.client.internal.mqtt.message.connect.connack.MqttConnAck;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
 import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
 import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect;
 import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
+import io.bonitoo.qa.VirtualDeviceRuntimeException;
 import io.bonitoo.qa.conf.mqtt.broker.BrokerConfig;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.LockSupport;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,7 +33,7 @@ public class MqttClientAsync extends AbstractMqttClient {
 
   Mqtt5AsyncClient client;
 
-  private MqttClientAsync() {
+  protected MqttClientAsync() {
     super();
   }
 
@@ -58,7 +62,16 @@ public class MqttClientAsync extends AbstractMqttClient {
   @Override
   public MqttClient connect() throws InterruptedException {
     // todo implement - see MqttClientBlocking
-    return null;
+    try {
+      Mqtt5ConnAck ack = this.client.connect().get(5000, TimeUnit.MILLISECONDS);
+
+      System.out.println("DEBUG ack " + ack);
+
+    } catch (ExecutionException | TimeoutException e) {
+      throw new VirtualDeviceRuntimeException("failed to connect to broker in 5 seconds", e);
+    }
+
+    return this;
   }
 
   @Override

--- a/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientBlocking.java
+++ b/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientBlocking.java
@@ -32,7 +32,7 @@ public class MqttClientBlocking extends AbstractMqttClient {
 
   Mqtt5BlockingClient client;
 
-  private MqttClientBlocking() {
+  protected MqttClientBlocking() {
     super();
   }
 
@@ -72,6 +72,11 @@ public class MqttClientBlocking extends AbstractMqttClient {
     mcb.client = clientBuilder.buildBlocking();
 
     return mcb;
+  }
+
+  // TODO review if this is needed
+  protected MqttClientBlocking(VirDevMqttClientBuilder builder){
+
   }
 
   @Override

--- a/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientBlocking.java
+++ b/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientBlocking.java
@@ -74,11 +74,6 @@ public class MqttClientBlocking extends AbstractMqttClient {
     return mcb;
   }
 
-  // TODO review if this is needed
-  protected MqttClientBlocking(VirDevMqttClientBuilder builder){
-
-  }
-
   @Override
   public MqttClient connect() throws InterruptedException {
     if (broker.getAuth() == null || broker.getAuth().getUsername() == null) {

--- a/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientRx.java
+++ b/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientRx.java
@@ -2,18 +2,25 @@ package io.bonitoo.qa.mqtt.client;
 
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5RxClient;
+import com.hivemq.client.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
 import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import io.bonitoo.qa.VirtualDeviceRuntimeException;
 import io.bonitoo.qa.conf.mqtt.broker.BrokerConfig;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
+
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A reactiveX based MqttClient.
@@ -27,9 +34,11 @@ import lombok.Setter;
 @Getter
 public class MqttClientRx extends AbstractMqttClient {
 
+  static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   Mqtt5RxClient client;
 
-  private MqttClientRx() {
+  protected MqttClientRx() {
     super();
   }
 
@@ -44,39 +53,48 @@ public class MqttClientRx extends AbstractMqttClient {
     MqttClientRx mcr = new MqttClientRx();
     mcr.broker = broker;
     mcr.id = id;
-    mcr.client = Mqtt5Client.builder()
+    Mqtt5ClientBuilder clientBuilder = Mqtt5Client.builder()
       .identifier(id)
       .serverHost(broker.getHost())
-      .serverPort(broker.getPort())
-      .buildRx();
+      .serverPort(broker.getPort());
+
+    if(broker.getAuth() != null){
+      clientBuilder.simpleAuth(Mqtt5SimpleAuth.builder()
+        .username(broker.getAuth().getUsername())
+        .password(new String(broker.getAuth().getPassword()).getBytes())
+        .build());
+    }
+    // TODO TLS
+    mcr.client = clientBuilder.buildRx();
     return mcr;
   }
 
   @Override
   public MqttClient connect() throws InterruptedException {
-    // todo implement - see MqttClientBlocking
-    return null;
+
+    if (!client.connect()
+        .doOnSuccess(System.out::println)
+        .doOnError(System.err::println)
+        .ignoreElement()
+        .blockingAwait(5000, TimeUnit.MILLISECONDS)) {
+      throw new VirtualDeviceRuntimeException("Failed to connect to MqttBroker at "
+          + client.getConfig().getServerHost() + ":"
+          + client.getConfig().getServerPort());
+    }
+    return this;
   }
 
   @Override
   public MqttClient connectSimple(String username, String password) throws InterruptedException {
-    // TODO implement
-    return null;
+    // N.B. credentials are already handled in constructor
+    return this.connect();
   }
 
   @Override
   public MqttClient connectAnon() throws InterruptedException {
 
-    Single<Mqtt5ConnAck> singleAck = client.connect();
+    return this.connect();
 
-    Completable connectScenario = singleAck
-        .doAfterSuccess(connAck -> System.out.println("Rx CONNECTED " + connAck))
-        .doOnError(throwable -> System.out.println("Rx Failed to connect " + throwable))
-        .ignoreElement();
-
-    connectScenario.blockingAwait(5000, TimeUnit.MILLISECONDS);
-
-    return this;
   }
 
   @Override
@@ -104,8 +122,8 @@ public class MqttClientRx extends AbstractMqttClient {
   @Override
   public MqttClient disconnect() {
     Completable completable = client.disconnect()
-        .doOnComplete(() -> System.out.println("Rx Disconnected"))
-        .doOnError(throwable -> System.err.println("Failed to disconnect " + throwable));
+        .doOnComplete(() -> logger.info("Rx Disconnected"))
+        .doOnError(throwable -> logger.error("Failed to disconnect " + throwable));
 
     completable.blockingAwait(5000, TimeUnit.MILLISECONDS);
 

--- a/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientRx.java
+++ b/src/main/java/io/bonitoo/qa/mqtt/client/MqttClientRx.java
@@ -5,14 +5,11 @@ import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5RxClient;
 import com.hivemq.client.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
-import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
 import io.bonitoo.qa.VirtualDeviceRuntimeException;
 import io.bonitoo.qa.conf.mqtt.broker.BrokerConfig;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
-import io.reactivex.Single;
-
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
@@ -54,17 +51,16 @@ public class MqttClientRx extends AbstractMqttClient {
     mcr.broker = broker;
     mcr.id = id;
     Mqtt5ClientBuilder clientBuilder = Mqtt5Client.builder()
-      .identifier(id)
-      .serverHost(broker.getHost())
-      .serverPort(broker.getPort());
+        .identifier(id)
+        .serverHost(broker.getHost())
+        .serverPort(broker.getPort());
 
-    if(broker.getAuth() != null){
+    if (broker.getAuth() != null) {
       clientBuilder.simpleAuth(Mqtt5SimpleAuth.builder()
-        .username(broker.getAuth().getUsername())
-        .password(new String(broker.getAuth().getPassword()).getBytes())
-        .build());
+          .username(broker.getAuth().getUsername())
+          .password(new String(broker.getAuth().getPassword()).getBytes())
+          .build());
     }
-    // TODO TLS
     mcr.client = clientBuilder.buildRx();
     return mcr;
   }
@@ -130,6 +126,7 @@ public class MqttClientRx extends AbstractMqttClient {
     return this;
   }
 
+  // todo - review if the following is needed
   @Override
   public void shutdown() {
 

--- a/src/main/java/io/bonitoo/qa/mqtt/client/VirDevMqttClientBuilder.java
+++ b/src/main/java/io/bonitoo/qa/mqtt/client/VirDevMqttClientBuilder.java
@@ -1,0 +1,140 @@
+package io.bonitoo.qa.mqtt.client;
+
+import com.hivemq.client.mqtt.MqttClientSslConfig;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
+import com.hivemq.client.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
+import com.hivemq.client.util.KeyStoreUtil;
+import io.bonitoo.qa.VirtualDeviceRuntimeException;
+import io.bonitoo.qa.conf.Mode;
+import io.bonitoo.qa.conf.mqtt.broker.AuthConfig;
+import io.bonitoo.qa.conf.mqtt.broker.BrokerConfig;
+import io.bonitoo.qa.conf.mqtt.broker.TlsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
+import java.lang.invoke.MethodHandles;
+import java.util.UUID;
+
+public class VirDevMqttClientBuilder {
+
+  static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  AuthConfig authConfig;
+  TlsConfig tlsConfig;
+
+  BrokerConfig brokerConfig;
+
+  String id;
+
+  public VirDevMqttClientBuilder(BrokerConfig brokerConfig) {
+    this.brokerConfig = brokerConfig;
+    this.authConfig = brokerConfig.getAuth();
+    this.tlsConfig = brokerConfig.getTls();
+    id = UUID.randomUUID().toString();
+  }
+
+  private Mqtt5ClientBuilder startClientBuilder() {
+
+    Mqtt5ClientBuilder clientBuilder = Mqtt5Client.builder()
+        .identifier(this.id)
+        .serverHost(this.brokerConfig.getHost())
+        .serverPort(this.brokerConfig.getPort());
+
+    if (this.authConfig != null) {
+      clientBuilder.simpleAuth(Mqtt5SimpleAuth.builder()
+          .username(this.authConfig.getUsername())
+          .password(new String(this.authConfig.getPassword()).getBytes())
+          .build());
+    }
+
+    if (this.tlsConfig != null) {
+      try {
+        TrustManagerFactory trustManagerFactory = KeyStoreUtil
+            .trustManagerFromKeystore(new File(this.tlsConfig.getTrustStore()),
+              new String(this.tlsConfig.getTrustPass()));
+        clientBuilder.sslConfig(MqttClientSslConfig.builder()
+            .keyManagerFactory(null)
+            .trustManagerFactory(trustManagerFactory)
+            .build()
+        );
+      } catch (SSLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    return clientBuilder;
+  }
+
+  public MqttClientBlocking buildBlocking() {
+    MqttClientBlocking clientBlocking = new MqttClientBlocking();
+    clientBlocking.setBroker(this.brokerConfig);
+    clientBlocking.setId(this.id);
+    clientBlocking.setClient(startClientBuilder().buildBlocking());
+    return clientBlocking;
+  }
+
+  public MqttClientRx buildRx() {
+    MqttClientRx clientRx = new MqttClientRx();
+    clientRx.setBroker(this.brokerConfig);
+    clientRx.setId(this.id);
+    clientRx.setClient(startClientBuilder().buildRx());
+    return clientRx;
+  }
+
+  public MqttClientAsync buildAsync() {
+    MqttClientAsync clientAsync = new MqttClientAsync();
+    clientAsync.setBroker(this.brokerConfig);
+    clientAsync.setId(this.id);
+    clientAsync.setClient(startClientBuilder().buildAsync());
+    return clientAsync;
+  }
+
+  public VirDevMqttClientBuilder authConfig(AuthConfig authconfig) {
+    this.authConfig = authconfig;
+    return this;
+  }
+
+  public VirDevMqttClientBuilder tlsConfig(TlsConfig tlsconfig) {
+    this.tlsConfig = tlsconfig;
+    return this;
+  }
+
+  public VirDevMqttClientBuilder brokerConfig(BrokerConfig brokerconfig) {
+    this.brokerConfig = brokerconfig;
+    this.tlsConfig = brokerconfig.getTls();
+    this.authConfig = brokerconfig.getAuth();
+    return this;
+  }
+
+  public VirDevMqttClientBuilder id(String id) {
+    this.id = id;
+    return this;
+  }
+
+  public MqttClient genClientFromMode(Mode mode) {
+    switch (mode) {
+      case ASYNC:
+        logger.info("Generating Async Client");
+        // return MqttClientAsync.client(config, id);
+        return buildAsync();
+      case REACTIVE:
+        logger.info("Generating Reactive Client");
+        // return MqttClientRx.client(config, id);
+        return buildRx();
+      case BLOCKING:
+        logger.info("Generating Blocking Client");
+        // return MqttClientBlocking.client(config, id);
+        return buildBlocking();
+      default:
+        throw new VirtualDeviceRuntimeException(
+          "Cannot create client of unknown mode: " + mode
+        );
+    }
+
+  }
+
+}

--- a/src/main/java/io/bonitoo/qa/mqtt/client/VirDevMqttClientBuilder.java
+++ b/src/main/java/io/bonitoo/qa/mqtt/client/VirDevMqttClientBuilder.java
@@ -10,15 +10,17 @@ import io.bonitoo.qa.conf.Mode;
 import io.bonitoo.qa.conf.mqtt.broker.AuthConfig;
 import io.bonitoo.qa.conf.mqtt.broker.BrokerConfig;
 import io.bonitoo.qa.conf.mqtt.broker.TlsConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLException;
-import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
 import java.lang.invoke.MethodHandles;
 import java.util.UUID;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * A builder for generating the various possible MqttClients.
+ */
 public class VirDevMqttClientBuilder {
 
   static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -30,6 +32,11 @@ public class VirDevMqttClientBuilder {
 
   String id;
 
+  /**
+   * Constructs a new builder beginning with the brokerConfig.
+   *
+   * @param brokerConfig - a base BrokerConfig.
+   */
   public VirDevMqttClientBuilder(BrokerConfig brokerConfig) {
     this.brokerConfig = brokerConfig;
     this.authConfig = brokerConfig.getAuth();
@@ -69,6 +76,11 @@ public class VirDevMqttClientBuilder {
     return clientBuilder;
   }
 
+  /**
+   * Builds a new blocking MqttClient.
+   *
+   * @return - a new MqttClientBlocking instance.
+   */
   public MqttClientBlocking buildBlocking() {
     MqttClientBlocking clientBlocking = new MqttClientBlocking();
     clientBlocking.setBroker(this.brokerConfig);
@@ -77,6 +89,11 @@ public class VirDevMqttClientBuilder {
     return clientBlocking;
   }
 
+  /**
+   * Builds a reactivex based MqttClient.
+   *
+   * @return - a new MqttClientRx instance.
+   */
   public MqttClientRx buildRx() {
     MqttClientRx clientRx = new MqttClientRx();
     clientRx.setBroker(this.brokerConfig);
@@ -85,6 +102,11 @@ public class VirDevMqttClientBuilder {
     return clientRx;
   }
 
+  /**
+   * Builds an AsyncClient based on previously defined values.
+   *
+   * @return - a new MqttClientAssync instance.
+   */
   public MqttClientAsync buildAsync() {
     MqttClientAsync clientAsync = new MqttClientAsync();
     clientAsync.setBroker(this.brokerConfig);
@@ -93,16 +115,34 @@ public class VirDevMqttClientBuilder {
     return clientAsync;
   }
 
+  /**
+   * Adds an AuthConfig to the builder.
+   *
+   * @param authconfig - AuthConfig to add.
+   * @return - this builder.
+   */
   public VirDevMqttClientBuilder authConfig(AuthConfig authconfig) {
     this.authConfig = authconfig;
     return this;
   }
 
+  /**
+   * Adds a TlsConfig to the builder.
+   *
+   * @param tlsconfig - TlsConfig to be added.
+   * @return - this builder.
+   */
   public VirDevMqttClientBuilder tlsConfig(TlsConfig tlsconfig) {
     this.tlsConfig = tlsconfig;
     return this;
   }
 
+  /**
+   * Adds a BrokerConfig to the builder.
+   *
+   * @param brokerconfig - BrokerConfig to be added.
+   * @return - this builder.
+   */
   public VirDevMqttClientBuilder brokerConfig(BrokerConfig brokerconfig) {
     this.brokerConfig = brokerconfig;
     this.tlsConfig = brokerconfig.getTls();
@@ -115,6 +155,12 @@ public class VirDevMqttClientBuilder {
     return this;
   }
 
+  /**
+   * Factory style method for creating different types of clients.
+   *
+   * @param mode - the mode of client to be generated.
+   * @return - a new MqttClient.
+   */
   public MqttClient genClientFromMode(Mode mode) {
     switch (mode) {
       case ASYNC:

--- a/src/main/java/io/bonitoo/qa/util/VirDevWorkInProgressException.java
+++ b/src/main/java/io/bonitoo/qa/util/VirDevWorkInProgressException.java
@@ -1,5 +1,9 @@
 package io.bonitoo.qa.util;
 
+/**
+ * Exception to be used with methods that are not yet implemented,
+ * but may be needed as placeholders or reminders for future work.
+ */
 public class VirDevWorkInProgressException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;

--- a/src/main/java/io/bonitoo/qa/util/VirDevWorkInProgressException.java
+++ b/src/main/java/io/bonitoo/qa/util/VirDevWorkInProgressException.java
@@ -1,0 +1,17 @@
+package io.bonitoo.qa.util;
+
+public class VirDevWorkInProgressException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public VirDevWorkInProgressException() {
+  }
+
+  public VirDevWorkInProgressException(String message) {
+    super(message);
+  }
+
+  public VirDevWorkInProgressException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/test/java/io/bonitoo/qa/DeviceRunnerTest.java
+++ b/src/test/java/io/bonitoo/qa/DeviceRunnerTest.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.bonitoo.qa.conf.Mode;
 import io.bonitoo.qa.conf.RunnerConfig;
+import io.bonitoo.qa.conf.RunnerConfigDeserializer;
 import io.bonitoo.qa.conf.data.*;
 import io.bonitoo.qa.conf.device.DeviceConfig;
 import io.bonitoo.qa.conf.mqtt.broker.AuthConfig;
@@ -81,11 +83,13 @@ public class DeviceRunnerTest {
 
         BrokerConfig broker = new BrokerConfig("my.mqttserver.net", 1883, new AuthConfig("fred", "changeit".toCharArray()));
 
-        RunnerConfig runnerConf = new RunnerConfig(broker, Arrays.asList(device), 30000l);
+        RunnerConfig runnerConf = new RunnerConfig(broker, Arrays.asList(device), 30000l, Mode.BLOCKING);
 
         ObjectWriter writer = new ObjectMapper(new YAMLFactory()).writer().withDefaultPrettyPrinter();
 
         String confAsYaml = writer.writeValueAsString(runnerConf);
+
+        System.out.println("DEBUG confAsYaml:\n" + confAsYaml);
 
         ObjectMapper om = new ObjectMapper(new YAMLFactory());
 
@@ -93,6 +97,7 @@ public class DeviceRunnerTest {
 
         assertEquals(runnerConf.getTtl(), parsedConf.getTtl());
         assertEquals(runnerConf.getBroker(), parsedConf.getBroker());
+        assertEquals(runnerConf.getMode(), parsedConf.getMode());
 
         for(DeviceConfig deviceConf: runnerConf.getDevices()){
             assertTrue(parsedConf.getDevices().contains(deviceConf));
@@ -100,6 +105,6 @@ public class DeviceRunnerTest {
         for(DeviceConfig deviceConf: parsedConf.getDevices()){
             assertTrue(runnerConf.getDevices().contains(deviceConf));
         }
-
     }
+
 }

--- a/src/test/java/io/bonitoo/qa/DeviceRunnerTest.java
+++ b/src/test/java/io/bonitoo/qa/DeviceRunnerTest.java
@@ -14,6 +14,8 @@ import io.bonitoo.qa.conf.mqtt.broker.BrokerConfig;
 import io.bonitoo.qa.data.ItemType;
 import io.bonitoo.qa.data.generator.NumGenerator;
 import io.bonitoo.qa.conf.Config;
+import io.bonitoo.qa.device.Device;
+import io.bonitoo.qa.device.TestDevice;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -104,6 +107,20 @@ public class DeviceRunnerTest {
         }
         for(DeviceConfig deviceConf: parsedConf.getDevices()){
             assertTrue(runnerConf.getDevices().contains(deviceConf));
+        }
+    }
+
+    @Test
+    public void checkRunnerReactiveBranch() throws InterruptedException {
+
+        List<Device> tds = Arrays.asList(new TestDevice(), new TestDevice(), new TestDevice());
+
+        DeviceRunner.reactiveMain(tds);
+
+        Thread.sleep(1000L);
+
+        for(Device dev : tds){
+            assertTrue(((TestDevice)dev).isCalled());
         }
     }
 

--- a/src/test/java/io/bonitoo/qa/conf/RunnerConfigDeserializerTest.java
+++ b/src/test/java/io/bonitoo/qa/conf/RunnerConfigDeserializerTest.java
@@ -1,0 +1,50 @@
+package io.bonitoo.qa.conf;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("unit")
+public class RunnerConfigDeserializerTest {
+
+  @Test
+  public void parseModeBlockingTest(){
+    assertEquals(Mode.BLOCKING, RunnerConfigDeserializer.parseMode("blocking"));
+    assertEquals(Mode.BLOCKING, RunnerConfigDeserializer.parseMode("Blocking"));
+    assertEquals(Mode.BLOCKING, RunnerConfigDeserializer.parseMode("BLOCKING"));
+    assertEquals(Mode.BLOCKING, RunnerConfigDeserializer.parseMode("block"));
+    assertEquals(Mode.BLOCKING, RunnerConfigDeserializer.parseMode("Block"));
+    assertEquals(Mode.BLOCKING, RunnerConfigDeserializer.parseMode("BLOCK"));
+  }
+
+  @Test
+  public void parseModeReactiveTest(){
+    assertEquals(Mode.REACTIVE, RunnerConfigDeserializer.parseMode("reactive"));
+    assertEquals(Mode.REACTIVE, RunnerConfigDeserializer.parseMode("Reactive"));
+    assertEquals(Mode.REACTIVE, RunnerConfigDeserializer.parseMode("REACTIVE"));
+    assertEquals(Mode.REACTIVE, RunnerConfigDeserializer.parseMode("reactivex"));
+    assertEquals(Mode.REACTIVE, RunnerConfigDeserializer.parseMode("Reactivex"));
+    assertEquals(Mode.REACTIVE, RunnerConfigDeserializer.parseMode("REACTIVEX"));
+    assertEquals(Mode.REACTIVE, RunnerConfigDeserializer.parseMode("rx"));
+    assertEquals(Mode.REACTIVE, RunnerConfigDeserializer.parseMode("Rx"));
+    assertEquals(Mode.REACTIVE, RunnerConfigDeserializer.parseMode("RX"));
+  }
+
+  @Test
+  public void parseModeAsyncTest(){
+    assertEquals(Mode.ASYNC, RunnerConfigDeserializer.parseMode("asynchronous"));
+    assertEquals(Mode.ASYNC, RunnerConfigDeserializer.parseMode("Asynchronous"));
+    assertEquals(Mode.ASYNC, RunnerConfigDeserializer.parseMode("ASYNCHRONOUS"));
+    assertEquals(Mode.ASYNC, RunnerConfigDeserializer.parseMode("async"));
+    assertEquals(Mode.ASYNC, RunnerConfigDeserializer.parseMode("Async"));
+    assertEquals(Mode.ASYNC, RunnerConfigDeserializer.parseMode("ASYNC"));
+  }
+
+  @Test
+  public void parseModeInvalidTest(){
+    assertThrows(VirDevConfigException.class, () -> RunnerConfigDeserializer.parseMode("SpongeBob"));
+  }
+
+}

--- a/src/test/java/io/bonitoo/qa/device/BlockingDeviceTest.java
+++ b/src/test/java/io/bonitoo/qa/device/BlockingDeviceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
 
 @Tag("intg")
 @ExtendWith(MockitoExtension.class)
-public class DeviceTest {
+public class BlockingDeviceTest {
 
     static long origTTL;
     @Mock

--- a/src/test/java/io/bonitoo/qa/device/ReactiveDeviceTest.java
+++ b/src/test/java/io/bonitoo/qa/device/ReactiveDeviceTest.java
@@ -119,20 +119,6 @@ public class ReactiveDeviceTest {
     verify(mHiveClient, times(1)).disconnect();
   }
 
-  @Test
-  public void checkRunnerReactiveBranch() throws InterruptedException {
-
-    List<Device> tds = Arrays.asList(new TestDevice(), new TestDevice(), new TestDevice());
-
-    DeviceRunner.reactiveMain(tds);
-
-    Thread.sleep(1000L);
-
-   for(Device dev : tds){
-      assertTrue(((TestDevice)dev).isCalled());
-    }
-  }
-
   // N.B. using reactivex TestSubscriber
   @Test
   public void checkFlowableSamples() throws InterruptedException, JsonProcessingException {

--- a/src/test/java/io/bonitoo/qa/device/ReactiveDeviceTest.java
+++ b/src/test/java/io/bonitoo/qa/device/ReactiveDeviceTest.java
@@ -1,0 +1,200 @@
+package io.bonitoo.qa.device;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hivemq.client.internal.mqtt.MqttRxClient;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishResult;
+import io.bonitoo.qa.DeviceRunner;
+import io.bonitoo.qa.conf.Config;
+import io.bonitoo.qa.conf.Mode;
+import io.bonitoo.qa.conf.data.ItemConfig;
+import io.bonitoo.qa.conf.data.ItemNumConfig;
+import io.bonitoo.qa.conf.data.SampleConfig;
+import io.bonitoo.qa.conf.device.DeviceConfig;
+import io.bonitoo.qa.data.ItemType;
+import io.bonitoo.qa.data.Sample;
+import io.bonitoo.qa.data.generator.NumGenerator;
+import io.bonitoo.qa.mqtt.client.MqttClientRx;
+import io.bonitoo.qa.mqtt.client.VirDevMqttClientBuilder;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.reactivex.subscribers.TestSubscriber;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@Tag("intg")
+@ExtendWith(MockitoExtension.class)
+public class ReactiveDeviceTest {
+
+  static long origTTL;
+
+  @Mock
+  MqttRxClient mHiveClient;
+
+  @Mock
+  Mqtt5ConnAck mockHiveAck;
+
+  @BeforeEach
+  public void setup() throws InterruptedException {
+    reset(mHiveClient);
+    reset(mockHiveAck);
+    lenient().when(mHiveClient.connect()).thenReturn(Single.just(mockHiveAck));
+    lenient().when(mHiveClient.publish(any())).thenReturn(Flowable.just(new Mqtt5PublishResult() {
+      @Override
+      public @NotNull Mqtt5Publish getPublish() {
+        return null;
+      }
+
+      @Override
+      public @NotNull Optional<Throwable> getError() {
+        return Optional.empty();
+      }
+    }));
+    lenient().when(mHiveClient.disconnect()).thenReturn(Completable.fromAction(() -> {}));
+    Config.reset();
+    // N.B. changing values in static Config can impact other tests
+    origTTL = Config.ttl();
+  }
+
+  @AfterEach
+  public void resetAny(){
+    // N.B. changing values in static Config can impact other tests
+    Config.getRunnerConfig().setTtl(origTTL);
+  }
+
+  @Test
+  public void genericDeviceRxBaseTest() throws InterruptedException {
+
+    ItemConfig iConf = new ItemNumConfig("testItem", "anyVal", ItemType.Double, 0, 100, 1.0, NumGenerator.DEFAULT_DEV);
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    Config.getRunnerConfig().sampleConf(0, 0).setItems(Arrays.asList(iConf));
+    Config.getRunnerConfig().setTtl(1000l);
+    Config.getRunnerConfig().setMode(Mode.REACTIVE);
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(Config.getBrokerConf());
+    builder.id("ASDF Client");
+    MqttClientRx clientRx = builder.buildRx();
+    clientRx.setClient(mHiveClient);
+
+    assertEquals(2, Config.getDeviceConfs().size());
+    assertEquals(2, Config.getSampleConfs(0).size());
+
+    DeviceConfig devConf = Config.deviceConf(0);
+    devConf.setInterval(500L);
+
+    GenericDevice device = GenericDevice.singleDevice(clientRx, devConf);
+
+    executor.execute(device);
+
+    executor.awaitTermination(Config.ttl(), TimeUnit.MILLISECONDS);
+
+    executor.shutdown();
+
+    verify(mHiveClient, times(1)).connect();
+    // N.B. publish **Flowable** in Reactivex gets called only once - then flow begins
+    verify(mHiveClient, times(1)).publish(any());
+    verify(mHiveClient, times(1)).disconnect();
+  }
+
+  @Test
+  public void checkRunnerReactiveBranch() throws InterruptedException {
+
+    List<Device> tds = Arrays.asList(new TestDevice(), new TestDevice(), new TestDevice());
+
+    DeviceRunner.reactiveMain(tds);
+
+    Thread.sleep(1000L);
+
+   for(Device dev : tds){
+      assertTrue(((TestDevice)dev).isCalled());
+    }
+  }
+
+  // N.B. using reactivex TestSubscriber
+  @Test
+  public void checkFlowableSamples() throws InterruptedException, JsonProcessingException {
+
+    ItemConfig iConf1 = new ItemNumConfig("adam", "zebra", ItemType.Double, 0, 100, 1.0, NumGenerator.DEFAULT_DEV);
+    ItemConfig iConf2 = new ItemNumConfig("baker", "yuma", ItemType.Double, -25, 25, 1.0, NumGenerator.DEFAULT_DEV);
+    ItemConfig iConf3 = new ItemNumConfig("charlie", "x-ray", ItemType.Long, 1, 55, 1.0, NumGenerator.DEFAULT_DEV);
+
+    SampleConfig sConf1 = new SampleConfig("deltaTest01", "delta", "test/delta", Collections.singletonList(iConf1));
+    SampleConfig sConf2 = new SampleConfig("easyTest01", "easy", "test/easy", Arrays.asList(iConf2, iConf3));
+
+    // ClientRx Needed to create device, but will be ignored
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(Config.getBrokerConf());
+    builder.id("ASDF Client");
+    MqttClientRx clientRx = builder.buildRx();
+    clientRx.setClient(mHiveClient);
+
+    DeviceConfig devConf = new DeviceConfig("foxDevice01","foxDevice", "A test Device", Arrays.asList(sConf1, sConf2), 500L, 0L, 1);
+
+    GenericDevice device = new GenericDevice(clientRx, devConf, 1);
+
+    Flowable<Sample> sampleFlowable = Flowable.fromIterable(device.getSampleList())
+      .doOnNext(Sample::update)
+      .doOnError(System.err::println)
+      .doOnComplete(() -> {
+//        System.out.println("Flowable<Sample> complete on thread " + Thread.currentThread().getName());
+      })
+      .doOnCancel(() -> {
+        System.out.println("Flowable<Sample> cancelled");
+      })
+      .repeat(5);
+
+    TestSubscriber<Sample> testSubscriber = sampleFlowable.test();
+
+    testSubscriber.await(1000L, TimeUnit.MILLISECONDS);
+
+    testSubscriber.assertComplete();
+    testSubscriber.assertNoErrors();
+    testSubscriber.assertValueCount(10);
+
+    IntStream.range(0, testSubscriber.values().size()).forEach(idx ->
+      {
+          Sample s = testSubscriber.values().get(idx);
+          if(idx % 2 == 0){
+            assertEquals("deltaTest01", s.getId());
+            assertEquals(1, s.getItems().size());
+            assertEquals("zebra", s.getItems().get("adam").get(0).getLabel());
+            Double dAdam = s.getItems().get("adam").get(0).asDouble();
+            assertTrue(dAdam >= 0 && dAdam <= 200);
+          }else{
+            assertEquals("easyTest01", s.getId());
+            assertEquals(2, s.getItems().size());
+            assertEquals("yuma", s.getItems().get("baker").get(0).getLabel());
+            assertEquals("x-ray", s.getItems().get("charlie").get(0).getLabel());
+            Double dBaker = s.getItems().get("baker").get(0).asDouble();
+            assertTrue(dBaker >= -50 && dBaker <= 50);
+            Long lCharlie = s.getItems().get("charlie").get(0).asLong();
+            assertTrue(lCharlie >= 0L && lCharlie <= 110L);
+          }
+      }
+    );
+
+  }
+
+}

--- a/src/test/java/io/bonitoo/qa/device/TestDevice.java
+++ b/src/test/java/io/bonitoo/qa/device/TestDevice.java
@@ -1,0 +1,15 @@
+package io.bonitoo.qa.device;
+
+public class TestDevice extends Device {
+
+  boolean called = false;
+
+  @Override
+  public void run(){
+    called = true;
+  }
+
+  public boolean isCalled() {
+    return called;
+  }
+}

--- a/src/test/java/io/bonitoo/qa/mqtt/client/VirDevMqttClientBuilderTest.java
+++ b/src/test/java/io/bonitoo/qa/mqtt/client/VirDevMqttClientBuilderTest.java
@@ -1,0 +1,316 @@
+package io.bonitoo.qa.mqtt.client;
+
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5RxClient;
+import io.bonitoo.qa.conf.mqtt.broker.AuthConfig;
+import io.bonitoo.qa.conf.mqtt.broker.BrokerConfig;
+import io.bonitoo.qa.conf.mqtt.broker.TlsConfig;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/*
+N.B. client.connect and client.publish can be uncommented to manually verify
+that the built clients actually work.
+ */
+@Tag("unit")
+public class VirDevMqttClientBuilderTest {
+
+  @Test
+  public void buildBlockingPlain() throws InterruptedException {
+
+    BrokerConfig config = new BrokerConfig("localhost", 1883, null);
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    MqttClientBlocking client = builder.buildBlocking();
+
+//    client.connect();
+
+    assertInstanceOf(Mqtt5BlockingClient.class, client.getClient());
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(1883, client.getClient().getConfig().getServerPort());
+    assertFalse(client.getClient().getConfig().getSimpleAuth().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+
+  }
+
+  @Test
+  public void buildBlockingSimpleAuth01() throws InterruptedException {
+
+    BrokerConfig config = new BrokerConfig("localhost", 1883, null);
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.authConfig(new AuthConfig("tester", "changeit".toCharArray()));
+    MqttClientBlocking client = builder.buildBlocking();
+
+   // client.connect();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(1883, client.getClient().getConfig().getServerPort());
+    assertNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSimpleAuth().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+  }
+
+  @Test
+  public void buildBlockingSimpleAuth02() throws InterruptedException {
+
+    BrokerConfig config = new BrokerConfig("localhost", 1883,
+      new AuthConfig("tester", "changeit".toCharArray()));
+    MqttClientBlocking client = (new VirDevMqttClientBuilder(config)).buildBlocking();
+
+//    client.connect();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(1883, client.getClient().getConfig().getServerPort());
+    assertNotNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSimpleAuth().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+
+  }
+
+  @Test
+  public void buildBlockingTLS() throws InterruptedException {
+
+    BrokerConfig config = new BrokerConfig("localhost", 8883, null);
+
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.tlsConfig(new TlsConfig("./scripts/keys/brokerTrust.jks","changeit".toCharArray()));
+    builder.id("TestClient");
+
+    MqttClientBlocking client = builder.buildBlocking();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(8883, client.getClient().getConfig().getServerPort());
+    assertNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSslConfig().isPresent());
+
+//    client.connect();
+
+//    client.publish("test/pokus", "TEST FROM UNIT TEST BLOCKING");
+
+  }
+
+  @Test
+  public void buildBlockingAllInConfig() throws InterruptedException {
+
+    BrokerConfig config = new BrokerConfig("localhost", 8883,
+      new AuthConfig("tester", "changeit".toCharArray()),
+      new TlsConfig("./scripts/keys/brokerTrust.jks","changeit".toCharArray()));
+
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.id("TestClient");
+
+    MqttClientBlocking client = builder.buildBlocking();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(8883, client.getClient().getConfig().getServerPort());
+    assertNotNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSslConfig().isPresent());
+
+//    client.connect();
+
+//    client.publish("test/pokus", "TEST FROM UNIT TEST BLOCKING");
+
+  }
+
+  @Test
+  public void buildRXSimple() throws InterruptedException {
+
+    BrokerConfig config = new BrokerConfig("localhost", 1883, null);
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    MqttClientRx client = builder.buildRx();
+
+//    client.connect();
+
+    assertInstanceOf(Mqtt5RxClient.class, client.getClient());
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(1883, client.getClient().getConfig().getServerPort());
+    assertFalse(client.getClient().getConfig().getSimpleAuth().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+
+  }
+
+  @Test
+  public void buildRXSimpleAuth01() throws InterruptedException {
+
+    BrokerConfig config = new BrokerConfig("localhost", 1883, null);
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.authConfig(new AuthConfig("tester", "changeit".toCharArray()));
+    MqttClientRx client = builder.buildRx();
+
+//    client.connect();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(1883, client.getClient().getConfig().getServerPort());
+    assertNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSimpleAuth().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+
+  }
+
+  @Test
+  public void buildRXSimpleAuth02() throws InterruptedException {
+
+    BrokerConfig config = new BrokerConfig("localhost", 1883,
+      new AuthConfig("tester", "changeit".toCharArray()));
+    MqttClientRx client = (new VirDevMqttClientBuilder(config)).buildRx();
+
+//    client.connect();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(1883, client.getClient().getConfig().getServerPort());
+    assertNotNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSimpleAuth().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+
+  }
+
+  @Test
+  public void buildRxTls() throws InterruptedException {
+    BrokerConfig config = new BrokerConfig("localhost", 8883, null);
+
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.tlsConfig(new TlsConfig("./scripts/keys/brokerTrust.jks","changeit".toCharArray()));
+    builder.id("TestClient");
+
+    MqttClientRx client = builder.buildRx();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(8883, client.getClient().getConfig().getServerPort());
+    assertNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSslConfig().isPresent());
+
+//    client.connect();
+
+//    client.publish("test/pokus", "TEST FROM UNIT TEST RX");
+
+  }
+
+  @Test
+  public void buildRxTlsSimpleAuth() throws InterruptedException {
+    BrokerConfig config = new BrokerConfig("localhost", 8883, null);
+
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.tlsConfig(new TlsConfig("./scripts/keys/brokerTrust.jks","changeit".toCharArray()));
+    builder.id("TestClient");
+    builder.authConfig(new AuthConfig("tester","changeit".toCharArray()));
+
+    MqttClientRx client = builder.buildRx();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(8883, client.getClient().getConfig().getServerPort());
+    assertNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSslConfig().isPresent());
+
+//    client.connect();
+
+//    client.publish("test/pokus", "TEST FROM UNIT TEST RX");
+
+  }
+
+  @Test
+  public void buildRXAllInConfig() throws InterruptedException {
+    BrokerConfig config = new BrokerConfig("localhost", 8883,
+      new AuthConfig("tester", "changeit".toCharArray()),
+      new TlsConfig("./scripts/keys/brokerTrust.jks","changeit".toCharArray()));
+
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.id("TestClient");
+
+    MqttClientRx client = builder.buildRx();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(8883, client.getClient().getConfig().getServerPort());
+    assertNotNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSslConfig().isPresent());
+
+//    client.connect();
+
+//    client.publish("test/pokus", "TEST FROM UNIT TEST RX");
+
+  }
+
+  @Test
+  public void buildAsyncSimple() throws InterruptedException {
+    BrokerConfig config = new BrokerConfig("localhost", 1883, null);
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    MqttClientAsync client = builder.buildAsync();
+
+//    client.connect();
+
+    assertInstanceOf(Mqtt5AsyncClient.class, client.getClient());
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(1883, client.getClient().getConfig().getServerPort());
+    assertFalse(client.getClient().getConfig().getSimpleAuth().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+
+//    client.publish("test/essaie", "TEST FROM UNIT TEST ASYNC");
+  }
+
+  @Test
+  public void buildAsyncSimpleAuth01() throws InterruptedException {
+
+    BrokerConfig config = new BrokerConfig("localhost", 1883, null);
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.authConfig(new AuthConfig("tester", "changeit".toCharArray()));
+    MqttClientAsync client = builder.buildAsync();
+
+//    client.connect();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(1883, client.getClient().getConfig().getServerPort());
+    assertNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSimpleAuth().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+    assertFalse(client.getClient().getConfig().getSslConfig().isPresent());
+
+  }
+
+  @Test
+  public void buildAsyncTls() throws InterruptedException {
+    BrokerConfig config = new BrokerConfig("localhost", 8883, null);
+
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.tlsConfig(new TlsConfig("./scripts/keys/brokerTrust.jks","changeit".toCharArray()));
+    builder.id("TestClient");
+
+    MqttClientAsync client = builder.buildAsync();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(8883, client.getClient().getConfig().getServerPort());
+    assertNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSslConfig().isPresent());
+
+//    client.connect();
+
+//    client.publish("test/pokus", "TEST FROM UNIT TEST ASYNC");
+
+  }
+
+  @Test
+  public void buildAsyncAllInConfig() throws InterruptedException {
+    BrokerConfig config = new BrokerConfig("localhost", 8883,
+      new AuthConfig("tester", "changeit".toCharArray()),
+      new TlsConfig("./scripts/keys/brokerTrust.jks","changeit".toCharArray()));
+
+    VirDevMqttClientBuilder builder = new VirDevMqttClientBuilder(config);
+    builder.id("TestClient");
+
+    MqttClientAsync client = builder.buildAsync();
+
+    assertEquals("localhost", client.getClient().getConfig().getServerHost());
+    assertEquals(8883, client.getClient().getConfig().getServerPort());
+    assertNotNull(client.getBroker().getAuth());
+    assertTrue(client.getClient().getConfig().getSslConfig().isPresent());
+
+//    client.connect();
+
+//    client.publish("test/pokus", "TEST FROM UNIT TEST ASYNC");
+
+  }
+
+}

--- a/src/test/java/io/bonitoo/qa/plugin/util/EncryptPassTest.java
+++ b/src/test/java/io/bonitoo/qa/plugin/util/EncryptPassTest.java
@@ -51,12 +51,15 @@ public class EncryptPassTest {
   // to be used in dev environment ONLY
   /* @Test
   public void decrypt() {
-    final String hashedPass = "ENCqTJZQarWDANjbiKQRH1R5/Dw3jNtSIYq12fIt67sIPEAAAAQmi6eCz/B3DynfmBHkC30s9n9/ynDhlcNo2yDA7ma90k=";
+    // final String hashedPass = "ENCqTJZQarWDANjbiKQRH1R5/Dw3jNtSIYq12fIt67sIPEAAAAQmi6eCz/B3DynfmBHkC30s9n9/ynDhlcNo2yDA7ma90k=";
+    //final String hashedPass = "ENCptzZ5lFJiPgiAXLmsUKxQkBBrlNkWvjvoywMQ7LoIgYAAAAQQSj+DV5KHKg00w77iNHR2PX+8RzXBsWV6khadgnEB40=";
 
-    char[] pass = io.bonitoo.qa.util.EncryptPass.decryptTrustPass(TLSConfig.class.getPackage().getName(),
-        hashedPass);
+    //char[] pass = io.bonitoo.qa.util.EncryptPass.decryptTrustPass(TLSConfig.class.getPackage().getName(),
+    //    hashedPass);
+    // Following was to verify tokens from virtual-device-influx project
+   // char[] pass = EncryptPass.decryptPass("io.bonitoo.virtual.device.influx.conf.Config".toCharArray(), hashedPass);
     System.out.println("result:\n" + new String(pass));
 
-  } */
+  }*/
 
 }

--- a/src/test/resources/testRunnerRxConfig.yml
+++ b/src/test/resources/testRunnerRxConfig.yml
@@ -1,0 +1,80 @@
+---
+ttl: 10000
+mode: RX
+broker:
+  host: localhost
+  port: 1883
+  auth:
+    username: fred
+    password: changeit
+items:
+  - name: "tension"
+    type: "Double"
+    label: "bar"
+    max: 2.0
+    min: -1.0
+    period: 1
+  - name: "nuts"
+    type: "Long"
+    label: "nutcount"
+    max: 100.0
+    min: 1.0
+    period: 1
+  - name: "label"
+    type: "String"
+    label: "label"
+    values:
+      - "Salted"
+      - "unsalted"
+      - "smoked"
+samples:
+  - id: "random"
+    name: "alpha"
+    topic: "test/alpha"
+    items:
+      - "tension"
+      - "nuts"
+  - id: "random"
+    name: "beta"
+    topic: "test/beta"
+    items:
+      - "label"
+      - name: "flowRate"
+        label: "cmps"
+        type: Double
+        max: 30
+        min: 5
+        period: 2
+devices:
+  - id: "random"
+    name: "Test Device 01"
+    description: "testing device configuration"
+    interval: 500
+    jitter: 0
+    count: 1
+    samples:
+      - "alpha"
+      - "beta"
+  - id: "random"
+    name: "Test Device 02"
+    description: "test device configuration"
+    interval: 1000
+    jitter: 500
+    count: 1
+    samples:
+      - beta
+      - id: "random"
+        name: "gammaInline"
+        topic: "test/gamma"
+        items:
+          - name: "radiance"
+            type: "Double"
+            label: "lumens"
+            max: 27
+            min: 0.1
+            period: 2
+          - name: "appLabel"
+            type: "String"
+            label: "app"
+            values:
+              - "luminescence"

--- a/src/test/resources/testRunnerRxTlsConfig.yml
+++ b/src/test/resources/testRunnerRxTlsConfig.yml
@@ -1,0 +1,83 @@
+---
+ttl: 10000
+mode: Reactive
+broker:
+  host: localhost
+  port: 8883
+  auth:
+    username: fred
+    password: changeit
+  tls:
+    trustStore: "./scripts/keys/brokerTrust.jks"
+    trustPass: "ENCqTJZQarWDANjbiKQRH1R5/Dw3jNtSIYq12fIt67sIPEAAAAQmi6eCz/B3DynfmBHkC30s9n9/ynDhlcNo2yDA7ma90k="
+items:
+  - name: "tension"
+    type: "Double"
+    label: "bar"
+    max: 2.0
+    min: -1.0
+    period: 1
+  - name: "nuts"
+    type: "Long"
+    label: "nutcount"
+    max: 100.0
+    min: 1.0
+    period: 1
+  - name: "label"
+    type: "String"
+    label: "label"
+    values:
+      - "Salted"
+      - "unsalted"
+      - "smoked"
+samples:
+  - id: "random"
+    name: "alpha"
+    topic: "test/alpha"
+    items:
+      - "tension"
+      - "nuts"
+  - id: "random"
+    name: "beta"
+    topic: "test/beta"
+    items:
+      - "label"
+      - name: "flowRate"
+        label: "cmps"
+        type: Double
+        max: 30
+        min: 5
+        period: 2
+devices:
+  - id: "random"
+    name: "Test Device 01"
+    description: "testing device configuration"
+    interval: 1000
+    jitter: 0
+    count: 1
+    samples:
+      - "alpha"
+      - "beta"
+  - id: "random"
+    name: "Test Device 02"
+    description: "test device configuration"
+    interval: 3000
+    jitter: 500
+    count: 1
+    samples:
+      - beta
+      - id: "random"
+        name: "gammaInline"
+        topic: "test/gamma"
+        items:
+          - name: "radiance"
+            type: "Double"
+            label: "lumens"
+            max: 27
+            min: 0.1
+            period: 2
+          - name: "appLabel"
+            type: "String"
+            label: "app"
+            values:
+              - "luminescence"


### PR DESCRIPTION
Adds
   * Client modes to runner
   * Support for a `reactivex` mode 
   * `VirDevMqttClientBuilder` - to replace calls to constructors or similar and to facilitate creating a variety of client types. 
   * targets in support scripts to demonstrate using the reactivex mode of handling client broker communications. 